### PR TITLE
Update apv.md

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -253,6 +253,7 @@ Straf ⇨ Categorie 7: permanente ban
 	* Een nieuw account aanmaken om een ban te omzijlen.
 	* Een nieuw account aanmaken om het startersbedrag over te schrijven naar je lopende account.
 	* Een nieuw account aanmaken om opnieuw te beginnen. Hiervoor dient een ticket aangemaakt te worden.
+3. Ook accountsharing is niet toegestaan.
 	
 > Straf ⇨ Categorie 6: een ban van maximaal 1 maand
 


### PR DESCRIPTION
### Artikel 20 - Alternatieve karakters

1. Het is niet toegestaan om gebruik te maken van alternatieve accounts ('alt accounts') om enig voordeel te behalen.
2. Enkele voorbeelden hiervan zijn maar niet beperkt tot:
	* Een nieuw account aanmaken om een ban te omzijlen.
	* Een nieuw account aanmaken om het startersbedrag over te schrijven naar je lopende account.
	* Een nieuw account aanmaken om opnieuw te beginnen. Hiervoor dient een ticket aangemaakt te worden.
3. Ook accountsharing is niet toegestaan. (toegevoegd)